### PR TITLE
authentication: add Helmholtz AAI service

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,7 @@
 
 	<properties>
 		<java.version>11</java.version>
+		<version.spring-webmvc>5.2.6.RELEASE</version.spring-webmvc>
 	</properties>
 
 	<dependencies>
@@ -42,7 +43,7 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-webmvc</artifactId>
-			<version>5.2.6.RELEASE</version>
+			<version>${version.spring-webmvc}</version>
 		</dependency>
 	</dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,11 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-webmvc</artifactId>
+			<version>5.2.6.RELEASE</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/de/helmholtz/marketplace/webappserver/config/HelmholtzMarketplaceServerSecurityConfig.java
+++ b/src/main/java/de/helmholtz/marketplace/webappserver/config/HelmholtzMarketplaceServerSecurityConfig.java
@@ -1,0 +1,40 @@
+package de.helmholtz.marketplace.webappserver.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.web.authentication.HttpStatusEntryPoint;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
+
+@Configuration
+@EnableWebSecurity
+public class HelmholtzMarketplaceServerSecurityConfig extends WebSecurityConfigurerAdapter
+{
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        SimpleUrlAuthenticationFailureHandler handler = new SimpleUrlAuthenticationFailureHandler("/");
+
+        // @formatter:off
+        http
+            .authorizeRequests(requests -> requests
+                    .antMatchers("/", "/error").permitAll()
+                    .anyRequest().authenticated()
+            )
+            .exceptionHandling(error -> error
+                    .authenticationEntryPoint(new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED))
+            )
+            .logout(l -> l
+                    .logoutSuccessUrl("/").permitAll()
+            )
+            .oauth2Login(o -> o
+                    .failureHandler((request, response, exception) -> {
+                        request.getSession().setAttribute("error.message", exception.getMessage());
+                        handler.onAuthenticationFailure(request, response, exception);
+                    })
+            );
+        // @formatter:on
+    }
+}

--- a/src/main/java/de/helmholtz/marketplace/webappserver/controller/UtilityController.java
+++ b/src/main/java/de/helmholtz/marketplace/webappserver/controller/UtilityController.java
@@ -1,0 +1,42 @@
+package de.helmholtz.marketplace.webappserver.controller;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.web.csrf.CsrfToken;
+import org.springframework.web.bind.annotation.*;
+
+import javax.servlet.http.HttpServletRequest;
+
+@RestController
+public class UtilityController
+{
+    @Autowired
+    private OAuth2AuthorizedClientService authorizedClientService;
+
+    @GetMapping("/token")
+    public JsonNode getBearerToken(
+            OAuth2AuthenticationToken authentication) throws JsonProcessingException {
+        OAuth2AuthorizedClient client = authorizedClientService.loadAuthorizedClient(
+                authentication.getAuthorizedClientRegistrationId(), authentication.getName());
+        ObjectMapper mapper = new ObjectMapper();
+        return mapper.convertValue(client.getAccessToken(), JsonNode.class);
+    }
+
+    @GetMapping("/error")
+    @ResponseBody
+    public String error(HttpServletRequest request) {
+        String message = (String) request.getSession().getAttribute("error.message");
+        request.getSession().removeAttribute("error.message");
+        return message;
+    }
+
+    @GetMapping("/csrf")
+    public CsrfToken csrf(CsrfToken token) {
+        return token;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,1 +1,32 @@
+logging:
+  level:
+    root: INFO
+    org.springframework.web: INFO
+    org.springframework.security: INFO
+    org.springframework.security.oauth2: INFO
+    org.springframework.boot.autoconfigure: DEBUG
 
+spring:
+  security:
+    oauth2:
+      client:
+        registration:
+          unity:
+            provider: hdf
+            client-id: helmholtz-marketplace
+            client-secret: ${secret:nopass}
+            authorization-grant-type: authorization_code
+            redirect-uri: "{baseUrl}/login/oauth2/code/unity"
+            scope:
+              - credentials
+              - profile
+              - email
+            client-authentication-method: basic
+        provider:
+          hdf:
+            issuer-uri: https://login.helmholtz-data-federation.de/oauth2
+            authorization-uri: https://login.helmholtz-data-federation.de/oauth2-as/oauth2-authz
+            token-uri: https://login.helmholtz-data-federation.de/oauth2/token
+            user-info-uri: https://login.helmholtz-data-federation.de/oauth2/userinfo
+            jwk-set-uri: https://login.helmholtz-data-federation.de/oauth2/jwk
+            user-name-attribute: sub

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <title>Test Page</title>
+    </head>
+    <body>
+        <div>
+            <a href="/oauth2/authorization/unity">login</a>
+        </div>
+        <div>
+            <a href="/token">get token</a>
+        </div>
+        <div>
+            <a href="/csrf">csrf</a>
+        </div>
+        <div>
+            <a href="/logout">logout</a>
+        </div>
+    </body>
+</html>


### PR DESCRIPTION
Motivation:

The Helmholtz AAI service is a Identity and Authorisation Management 
(IAM) system which arbitrates authenticated access to registered 
services in the context of the Helmholtz Association. Integrating 
Helmholtz AAI service into the Helmholtz Marketplace is in alignment 
with the goal of this project.

Modification:

- authenticate user -> able to get token
- logout
- enable csrf support
- add spring mvc

Result:

User can now be authenticate using Helmholtz AAI.

Pull-request: #1